### PR TITLE
Allow digits in subversion username when generating authors list from svn log

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -153,7 +153,7 @@ repository which name on its own line. This would allow you to easily
 redirect the output of this command sequence to ~/.svn2git/authors and have
 a very good starting point for your mapping.
 
-    $ svn log | grep -E "r[0-9]+ \| [a-z]+ \|" | awk '{print $3}' | sort | uniq
+    $ svn log | grep -E "r[0-9]+ \| [a-z0-9]+ \|" | awk '{print $3}' | sort | uniq
 
 Debugging
 ---------


### PR DESCRIPTION
Hey, I've made a tiny change to the README to also select subversion usernames containing digits in the grep statement when generating the authors file. I don't know what characters svn usernames can contain by definition, but I've also seen a lot of usernames containing e.g. underscores; so you might want to think about adding that as well.
