### PR TITLE
fix for rebasing

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -168,13 +168,13 @@ module Svn2Git
       @remote = run_command("git branch -r --no-color").split(/\n/).collect{ |b| b.gsub(/\*/,'').strip }
 
       # Tags are remote branches that start with "tags/".
-      @tags = @remote.find_all { |b| b.strip =~ %r{^tags\/} }
+      @tags = @remote.find_all { |b| b.strip =~ %r{^svn\/tags\/} }
     end
 
     def fix_tags
       @tags.each do |tag|
         tag = tag.strip
-        id = tag.gsub(%r{^tags\/}, '').strip
+        id = tag.gsub(%r{^svn\/tags\/}, '').strip
         subject = run_command("git log -1 --pretty=format:'%s' #{tag}")
         date = run_command("git log -1 --pretty=format:'%ci' #{tag}")
         subject = escape_quotes(subject)
@@ -195,9 +195,9 @@ module Svn2Git
       
       svn_branches.each do |branch|
         branch = branch.gsub(/^svn\//,'').strip
-
         if @options[:rebase] && (@local.include?(branch) || branch == 'trunk')
-           lbranch = 'master' if branch == 'trunk' else lbranch = branch
+           lbranch = branch
+           lbranch = 'master' if branch == 'trunk'
            run_command("git checkout -f #{lbranch}")
            run_command("git rebase remotes/svn/#{branch}")
            next


### PR DESCRIPTION
These commits should fix some issues I was having with svn2git --rebase including that at least for me if one created another remote, rebasing would start creating a mess thinking that the remotes were in SVN.  As such, I prefixed all the svn remotes with "svn" so that it would be easy to separate svn remotes from others.

Commit message from first commit:
Attempt to fix problems with svn2git --rebase.
- Should no longer get confused by other remotes being added (so long as they are not named "svn")
- Should update branches from svn when svn2git --rebase is invoked

WARNING: Adds "svn" prefix to all remotes from svn, and later assumes this prefix when doing updates.  --rebase won't work with previously existing repositories that don't have this.
