### PR TITLE
added a continue flag

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -179,6 +179,11 @@ You can turn on verbose logging with the '-v' or '--verbose' flags, like so:
 
     $ svn2git http://svn.yoursite.com/path/to/repo --verbose
 
+In case you have git svn fetch errors you lay try to add '-c' or '--continue' flags 
+to you command line and run it again, like so:
+                          
+     $ svn2git http://svn.yoursite.com/path/to/repo --continue
+
 FAQ
 ---
 


### PR DESCRIPTION
I rebased this commit from mathieu/svn2git onto the latest source in your repository. Original commit message follows:

In case git svn crashes for some reason, running by hand
'git svn fetch' would continue to fetch revisions.
I added a continue flag to bypass init stage. I've tested it
succesfully against a big repository that I used for testing :
http://gitorious.org/openscenegraph/osg
