### PR TITLE
Correct svn branch detection

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -224,8 +224,8 @@ module Svn2Git
     end
 
     def fix_branches
-      svn_branches = @remote.find_all { |b| not @tags.include?(b) }
-      svn_branches = @remote.find_all { |b| b.strip =~ %r{^svn\/} }
+      svn_branches = @remote - @tags
+      svn_branches.delete_if { |b| b.strip !~ %r{^svn\/} }
 
       if @options[:rebase]
          run_command("git svn fetch")


### PR DESCRIPTION
The previous code didn't actually remove the tags from the list of svn_branches.  Note how svn_branches is set twice, not set once and operated on twice.

As a result you could get failures for a non-existent branch (because it was just deleted in the fix_tags code).
