### PR TITLE
Fix tag committer

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -217,14 +217,14 @@ module Svn2Git
       @tags.each do |tag|
         tag = tag.strip
         id      = tag.gsub(%r{^svn\/tags\/}, '').strip
-        subject = run_command("git log -1 --pretty=format:'%s' '#{tag}'")
-        date    = run_command("git log -1 --pretty=format:'%ci' '#{tag}'")
-        author  = run_command("git log -1 --pretty=format:'%an' '#{tag}'")
-        email   = run_command("git log -1 --pretty=format:'%ae' '#{tag}'")
+        subject = run_command("git log -1 --pretty=format:'%s' '#{escape_quotes(tag)}'")
+        date    = run_command("git log -1 --pretty=format:'%ci' '#{escape_quotes(tag)}'")
+        author  = run_command("git log -1 --pretty=format:'%an' '#{escape_quotes(tag)}'")
+        email   = run_command("git log -1 --pretty=format:'%ae' '#{escape_quotes(tag)}'")
         run_command("git config --local user.name '#{escape_quotes(author)}'")
         run_command("git config --local user.email '#{escape_quotes(email)}'")
         run_command("GIT_COMMITTER_DATE='#{escape_quotes(date)}' git tag -a -m '#{escape_quotes(subject)}' '#{escape_quotes(id)}' '#{escape_quotes(tag)}'")
-        run_command("git branch -d -r '#{tag}'")
+        run_command("git branch -d -r '#{escape_quotes(tag)}'")
       end
 
     ensure


### PR DESCRIPTION
These commits fix the tag migration to tag as the original tag committer (previously it would be whomever is running the conversion).  

Basically the changes detect the original author/email and then sets them as local git configs for the duration of the tag creation.  Then, afterwards it unsets the local configs just to cleanup.
