### PR TITLE
Make conversion exit on cmd error

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -267,11 +267,17 @@ module Svn2Git
 
       ret = ''
 
+      cmd = "2>&1 #{cmd}"
       IO.popen(cmd) do |stdout|
         stdout.each do |line|
           log line
           ret << line
         end
+      end
+
+      unless $?.exitstatus == 0
+        $stderr.puts "command failed:\n#{cmd}"
+        exit 1
       end
 
       ret


### PR DESCRIPTION
I found this useful so that a migration wouldn't just plow forward when a command fails, and subsequently error on something else.
