### PR TITLE
ensure svn author file is a local config

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -178,7 +178,7 @@ module Svn2Git
         run_command(cmd)
       end
 
-      run_command("git config svn.authorsfile #{authors}") unless authors.nil?
+      run_command("git config --local svn.authorsfile #{authors}") unless authors.nil?
 
       cmd = "git svn fetch "
       cmd += "-r #{revision}:HEAD " unless revision.nil?


### PR DESCRIPTION
The config stuff I was doing with the tags (see thinkerbot/svn2git@276a8e50d0848849c2c02c6d1911e4dbc94c8807) made me think that this should probably also be a local config.  Theoretically you could be converting multiple svn repos with different author files and it would be best to keep it out of the global configs.  

I can attest this works but it's likely inconsequential.  By the way, thanks for this library.  It's worked very well for a big migration and saved us a ton of time.
