### PR TITLE
Minor change to fix_tags

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -213,13 +213,13 @@ module Svn2Git
       @tags.each do |tag|
         tag = tag.strip
         id = tag.gsub(%r{^svn\/tags\/}, '').strip
-        subject = run_command("git log -1 --pretty=format:'%s' #{tag}")
-        date = run_command("git log -1 --pretty=format:'%ci' #{tag}")
+        subject = run_command("git log -1 --pretty=format:'%s' '#{tag}'")
+        date = run_command("git log -1 --pretty=format:'%ci' '#{tag}'")
         subject = escape_quotes(subject)
         date = escape_quotes(date)
         id = escape_quotes(id)
         run_command("GIT_COMMITTER_DATE='#{date}' git tag -a -m '#{subject}' '#{id}' '#{escape_quotes(tag)}'")
-        run_command("git branch -d -r #{tag}")
+        run_command("git branch -d -r '#{tag}'")
       end
     end
 


### PR DESCRIPTION
I have a repository I'm moving to git that has '(' and ')' characters in some tag names. These tag names caused fix_tags to fail because #{tag} was not quoted in some of those commands. I've added single quotes in those cases and can verify that it works for my repo now. Let me know if you have any questions.

Thanks,

Craig
