### PR TITLE
Tiny change to the README file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -174,7 +174,7 @@ repository which name on its own line. This would allow you to easily
 redirect the output of this command sequence to ~/.svn2git/authors and have
 a very good starting point for your mapping.
 
-    $ svn log | grep -E "r[0-9]+ \| .+ \|" | awk '{print $3}' | sort | uniq
+    $ svn log --quiet --xml | grep author | sort -u | sed 's:.*>\(.*\)<.*:\1 = :'
 
 Debugging
 ---------


### PR DESCRIPTION
Fixed the author extraction command in order to capture usernames with spaces. This version uses the xml log syntax and captures the content of the author element and formats it on the form 'author name = '
