### PR TITLE
Tags are not correctly updated with "svn2git --rebase" command. 

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -26,8 +26,8 @@ module Svn2Git
       else
         clone!
       end
-      fix_tags
       fix_branches
+      fix_tags
       fix_trunk
       optimize_repos
     end


### PR DESCRIPTION
Tags need to be fixed only after branches when using "svn2git --rebase". Otherwise tags are not yet fetched when attempting to fix them, resulting in tags not appearing as they should in git repository (they would only appear after a second  "svn2git --rebase").
