### PR TITLE
Updated example authors command

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -174,7 +174,7 @@ repository which name on its own line. This would allow you to easily
 redirect the output of this command sequence to ~/.svn2git/authors and have
 a very good starting point for your mapping.
 
-    $ svn log | grep -E "r[0-9]+ \| .+ \|" | awk '{print $3}' | sort | uniq
+    $ svn -q log http://path/to/root/of/project | grep -E "r[0-9]+ \| .+ \|" | awk '{print $3}' | sort | uniq
 
 Debugging
 ---------


### PR DESCRIPTION
Added -q option so that only the authors are shown in the output.
Added url example so that authors are pulled from entire history of that svn project
