### PR TITLE
Error: command failed: GIT_COMMITTER_DATE

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -220,7 +220,7 @@ module Svn2Git
 
       @tags.each do |tag|
         tag = tag.strip
-        id      = tag.gsub(%r{^svn\/tags\/}, '').strip
+        id      = tag.gsub(%r{^svn\/tags\/[-]*}, '').strip
         subject = run_command("git log -1 --pretty=format:'%s' '#{escape_quotes(tag)}'")
         date    = run_command("git log -1 --pretty=format:'%ci' '#{escape_quotes(tag)}'")
         author  = run_command("git log -1 --pretty=format:'%an' '#{escape_quotes(tag)}'")


### PR DESCRIPTION
One of my tagnames starts with -- which generates an error.

cli dumped here:

```

Running command: git log -1 --pretty=format:'%s' 'svn/tags/--20122302-0704--trunk'
release tag, of trunk version: 12.5
Running command: git log -1 --pretty=format:'%ci' 'svn/tags/--20122302-0704--trunk'
2012-02-23 06:04:38 +0000
Running command: git log -1 --pretty=format:'%an' 'svn/tags/--20122302-0704--trunk'
Running command: GIT_COMMITTER_DATE='2012-02-23 06:04:38 +0000' git tag -a -m 'release tag, of trunk version: 12.5' '--20122302-0704--trunk' 'svn/tags/--20122302-0704--trunk'
error: unknown option `20122302-0704--trunk'
usage: git tag [-a|-s|-u <key-id>] [-f] [-m <msg>|-F <file>] <tagname> [<head>]
   or: git tag -d <tagname>...
   or: git tag -l [-n[<num>]] [--contains <commit>] [--points-at <object>] 
                [<pattern>...]
   or: git tag -v <tagname>...

    -l, --list            list tag names
    -n[<n>]               print <n> lines of each tag message
    -d, --delete          delete tags
    -v, --verify          verify tags

Tag creation options
    -a, --annotate        annotated tag, needs a message
    -m, --message <message>
                          tag message
    -F, --file <file>     read message from file
    -s, --sign            annotated and GPG-signed tag
    --cleanup <mode>      how to strip spaces and #comments from message
    -u, --local-user <key-id>
                          use another key to sign the tag
    -f, --force           replace the tag if exists

Tag listing options
    --contains <commit>   print only tags that contain the commit
    --points-at <object>  print only tags of the object

command failed:
2>&1 GIT_COMMITTER_DATE='2012-02-23 06:04:38 +0000' git tag -a -m 'release tag, of trunk version: 12.5' '--20122302-0704--trunk' 'svn/tags/--20122302-0704--trunk'
```
