### PR TITLE
Fixes the problem with repositories with a white space in name.

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -16,7 +16,7 @@ module Svn2Git
       else
          show_help_message('Missing SVN_URL parameter') if args.empty?
          show_help_message('Too many arguments') if args.size > 1
-         @url = args.first
+         @url = args.first.gsub(" ", "\\ ")
       end
     end
 


### PR DESCRIPTION
Hi, this patch resolve the problem that occurs when you try to convert a repository with a space in the name. I tested it in Windows and Linux.
