### PR TITLE
Escape double-quotes as well as single-quotes

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -330,7 +330,7 @@ module Svn2Git
     end
 
     def escape_quotes(str)
-      str.gsub("'", "'\\\\''")
+      str.gsub("'", "'\\\\''").gsub('"', '"\\\\""')
     end
 
   end


### PR DESCRIPTION
This fixes a failure of 'git tag ...' when the commit message/annotation contains a double-quotes.
