### PR TITLE
Correct escaping of quotes and double quotes. (#89, #86)

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -330,7 +330,7 @@ module Svn2Git
     end
 
     def escape_quotes(str)
-      str.gsub("'", "'\\\\''")
+      str.gsub("'", "\\\\'").gsub('"', '\\\\"')
     end
 
   end


### PR DESCRIPTION
This fixes an issue that occured when the commit message/annotation
contains a double-quote.

For some reason the original code replaced a `'` with `'\''`.
the changed code replaces a `'` with `\'` and a `"` with `\"`.

this is related to issue #89, #86
