### PR TITLE
Documentation improvements: add full options reference and metadata example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -128,6 +128,10 @@ one of them.
 
         $ svn2git http://svn.example.com/path/to/repo --revision <<starting_revision_number>>:<<ending_revision_number>>
 
+10. Include metadata (git-svn-id) in git logs.
+
+        $ svn2git http://svn.example.com/path/to/repo --metadata
+
 The above will create a git repository in the current directory with the git
 version of the svn repository. Hence, you need to make a directory that you
 want your new git repo to exist in, change into it and then run one of the


### PR DESCRIPTION
Having the options reference in the documentation page is really handy... It takes hours to run the command on an old svn repo and knowing all the options up front would have saved me a lot of time.
