### PR TITLE
Avoid errors when creating a new tag by updating it instead.

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -230,7 +230,7 @@ module Svn2Git
 
         original_git_committer_date = ENV['GIT_COMMITTER_DATE']
         ENV['GIT_COMMITTER_DATE'] = escape_quotes(date)
-        run_command("git tag -a -m \"#{escape_quotes(subject)}\" \"#{escape_quotes(id)}\" \"#{escape_quotes(tag)}\"")
+        run_command("git tag -f -a -m \"#{escape_quotes(subject)}\" \"#{escape_quotes(id)}\" \"#{escape_quotes(tag)}\"")
         ENV['GIT_COMMITTER_DATE'] = original_git_committer_date
 
         run_command("git branch -d -r \"#{escape_quotes(tag)}\"")


### PR DESCRIPTION
The command was failing when there was an existing tag with the same name, With my change it says "Updated tag '<tagname>' (was aaaaaaaa)" instead of causing and error.
