### PR TITLE
run! method should respect --no* flag passed to svn2git

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -26,9 +26,9 @@ module Svn2Git
       else
         clone!
       end
-      fix_branches
-      fix_tags
-      fix_trunk
+      fix_branches unless @options[:branches].nil?
+      fix_tags unless @options[:tags].nil?
+      fix_trunk unless @options[:trunk].nil?
       optimize_repos
     end
 


### PR DESCRIPTION
This provides a workaround for the problem described in #106.

Basically it just makes sure `fix_trunk`, `fix_branches`, and `fix_tags` are not called in the `run!` method if `--notrunk`,  `--nobranches`,  or `--notags` respectively are passed to the svn2git command.

As of right now, the --no\* flags only appear to affect the initial git clone, not later rebases.
