### PR TITLE
Added double quote escaping for commit messages

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -330,7 +330,7 @@ module Svn2Git
     end
 
     def escape_quotes(str)
-      str.gsub("'", "'\\\\''").gsub("\"","\\\"")
+      str.gsub("'", "'\\\\''").gsub('"', '\"').gsub("\"","\\\"")
     end
 
   end


### PR DESCRIPTION
Hi! I was getting the error "Fatal: too many params", because some of the commit messages contained double quotes, the same as issue #118. I added escaping of double quotes in `escape_quotes(str)` to fix it.
