### PR TITLE
Explicitly require rubygems

### DIFF
--- a/bin/svn2git
+++ b/bin/svn2git
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require 'rubygems'
 require 'svn2git'
 
 migration = Svn2Git::Migration.new(ARGV)


### PR DESCRIPTION
Not every Ruby installation is setup to load rubygems automatically, so it is a good idea to require it before requiring svn2git gem.
