### PR TITLE
Update migration.rb

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -330,7 +330,8 @@ module Svn2Git
     end
 
     def escape_quotes(str)
-      str.gsub("'", "'\\\\''")
+      str.gsub("'", "\\\\'")
+      str.gsub("\"", "\\\\\"")
     end
 
   end


### PR DESCRIPTION
fixed escape_quotes to correctly escape single- and double-quotes
