### PR TITLE
fix creating branches.

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -270,8 +270,7 @@ module Svn2Git
         end
 
         next if branch == 'trunk' || @local.include?(branch)
-        run_command("git branch --track \"#{branch}\" \"remotes/svn/#{branch}\"")
-        run_command("git checkout \"#{branch}\"")
+        run_command("git checkout -b \"#{branch}\" \"remotes/svn/#{branch}\"")
       end
     end
 


### PR DESCRIPTION
fixes nirvdrum/svn2git/issues/142

Error output:

Running command: git branch --track "trunk@6615" "remotes/svn/trunk@6615"
fatal: Cannot setup tracking information; starting point 'remotes/svn/trunk@6615' is not a branch.
command failed:
2>&1 git branch --track "trunk@6615" "remotes/svn/trunk@6615"
