### PR TITLE
Fix bug in getting authors from svn repo

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -176,11 +176,11 @@ repository which name on its own line. This would allow you to easily
 redirect the output of this command sequence to `~/.svn2git/authors` and have
 a very good starting point for your mapping.
 
-    $ svn log --quiet | grep -E "r[0-9]+ \| .+ \|" | awk '{print $3}' | sort | uniq
+    $ svn log --quiet | grep -E "r[0-9]+ \| .+ \|" | cut -d'|' -f2 | sed 's/^ //' | sort | uniq
 
 Or, for a remote URL:
 
-    $ svn log --quiet http://path/to/root/of/project | grep -E "r[0-9]+ \| .+ \|" | awk '{print $3}' | sort | uniq
+    $ svn log --quiet http://path/to/root/of/project | grep -E "r[0-9]+ \| .+ \|" | cut -d'|' -f2 | sed 's/^ //' | sort | uniq
 
 Debugging
 ---------


### PR DESCRIPTION
This fixes a bug when there are spaces in the svn author names. I ran into this since Google Code's initial commit is done by the author `(no author)`, and the script would only print `(no`.

I had to add the `sed` to strip a leading space that slips through. If this can be done better, please improve.

```
svn log --quiet http://traycd.googlecode.com/svn/ | grep -E "r[0-9]+ \| .+ \|" | awk '{print $3}' | sort | uniq
```

incorrectly lists `(no`

```
svn log --quiet http://traycd.googlecode.com/svn/ | grep -E "r[0-9]+ \| .+ \|" | cut -d'|' -f2 | sed 's/^ //' | sort | uniq
```

correctly lists `(no author)`
