### PR TITLE
Fixing escape bug for multiple excludes in Git Bash in Windows

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -196,7 +196,7 @@ module Svn2Git
           regex << "#{branches}[/][^/]+[/]" unless branches.nil?
         end
         regex = '^(?:' + regex.join('|') + ')(?:' + exclude.join('|') + ')'
-        cmd += "'--ignore-paths=#{regex}'"
+        cmd += "\"--ignore-paths=#{regex}\""
       end
       run_command(cmd)
 


### PR DESCRIPTION
Getting an error "is not recognized as an internal or external command" when having multiple excludes in Git Bash in Windows 7. Changing from ' to " will fix the problem in Git Bash.

I have not tested the change in other environments then Git Bash + Windows 7

Before:

```
$ svn2git --username hallvard -m --authors ../svnauthors --rootistrunk --metadata -v http://svn/repos/url --exclude 'DirectoryA' --exclude 'DirectoryB'
Running command: git svn init --prefix=svn/ --username=hallvard --trunk=http://svn/repos/url
Initialized empty Git repository in c:/git/tmp/merge-test/mainRepo/.git/
Using higher level of URL: http://svn/repos/url => http://svn/repos/SVNRepo
Running command: git config --local svn.authorsfile ../svnauthors
Running command: git svn fetch '--ignore-paths=^(?:)(?:DirectoryA|DirectoryB)'
'DirectoryB)'' is not recognized as an internal or external command,
operable program or batch file.
command failed:
2>&1 git svn fetch '--ignore-paths=^(?:)(?:DirectoryA|DirectoryB)'
```

After

```
$ svn2git --username hallvard -m --authors ../svnauthors --rootistrunk --metadata -v http://svn/repos/url --exclude 'DirectoryA' --exclude 'DirectoryB'
Running command: git svn init --prefix=svn/ --username=hallvard --trunk=http://svn/repos/url
Initialized empty Git repository in c:/git/tmp/merge-test/mainRepo/.git/
Using higher level of URL: http://svn/repos/url => http://svn/repos/SVNRepo
Running command: git config --local svn.authorsfile ../svnauthors
(...)
```
