### PR TITLE
Ignorefiles

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -195,8 +195,8 @@ module Svn2Git
           regex << "#{tags}[/][^/]+[/]" unless tags.nil?
           regex << "#{branches}[/][^/]+[/]" unless branches.nil?
         end
-        regex = '^(?:' + regex.join('|') + ')(?:' + exclude.join('|') + ')'
-        cmd += "--ignore-paths=\"#{regex}\""
+        regex = '"^(?:' + regex.join('|') + ')(?:' + exclude.join('|') + ')"'
+        cmd += "--ignore-paths=#{regex}"
       end
       run_command(cmd)
 

--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -196,7 +196,7 @@ module Svn2Git
           regex << "#{branches}[/][^/]+[/]" unless branches.nil?
         end
         regex = '^(?:' + regex.join('|') + ')(?:' + exclude.join('|') + ')'
-        cmd += "'--ignore-paths=#{regex}'"
+        cmd += "--ignore-paths=\"#{regex}\""
       end
       run_command(cmd)
 


### PR DESCRIPTION
This change fixes the command line syntax required for --ignore-files.  I have tested it on Windows 7 with Ruby 1.9.3 and RubyGems 1.8.25