### PR TITLE
Added option to pass --authors-prog flag to "git svn fetch" command.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -68,7 +68,7 @@ Make sure you have git, git-svn, and ruby installed.  svn2git is a ruby wrapper 
 
     $ sudo apt-get install git-core git-svn ruby rubygems
 
-Once you have the necessary software on your system, you can install svn2git through rubygems, which will add the `svn2git` command to your PATH.    
+Once you have the necessary software on your system, you can install svn2git through rubygems, which will add the `svn2git` command to your PATH.
 
     $ sudo gem install svn2git
 
@@ -198,7 +198,7 @@ Options Reference
 
     $ svn2git --help
     Usage: svn2git SVN_URL [options]
-    
+
     Specific options:
             --rebase                     Instead of cloning a new project, rebase an existing one against SVN
             --username NAME              Username for transports that needs it (http(s), svn)
@@ -214,9 +214,10 @@ Options Reference
                                          Start importing from SVN revision START_REV; optionally end at END_REV
         -m, --metadata                   Include metadata in git logs (git-svn-id)
             --authors AUTHORS_FILE       Path to file containing svn-to-git authors mapping (default: ~/.svn2git/authors)
+            --authors-prog AUTHORS_PROG  Path to script containing svn-to-git authors mapping (default: ~/.svn2git/authors-prog)
             --exclude REGEX              Specify a Perl regular expression to filter paths when fetching; can be used multiple times
         -v, --verbose                    Be verbose in logging -- useful for debugging issues
-    
+
         -h, --help                       Show this message
 
 FAQ
@@ -229,9 +230,9 @@ FAQ
     Those commits are the first (head) commit of branch in svn that is
     associated with that tag. If you want to see all the branches and tags
     and their relationships in gitk you can run the following: gitk --all
-    
+
     For further details please refer to FAQ #2.
-    
+
 2. Why don't you reference the parent of the tag commits instead?
 
     In svn you are forced to create what are known in git as annotated tags.
@@ -241,7 +242,7 @@ FAQ
     treated as an annotated tag. Hence, for there to be a true 1-to-1 mapping
     between git and svn we have to transfer over the svn commit which acts as
     an annotated tag and then tag that commit in git using an annotated tag.
-    
+
     If we were to reference the parent of this svn tagged commit there could
     potentially be situations where a developer would checkout a tag in git
     and the resulting code base would be different than if they checked out

--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -3,6 +3,7 @@ require 'pp'
 
 module Svn2Git
   DEFAULT_AUTHORS_FILE = "~/.svn2git/authors"
+  DEFAULT_AUTHORS_PROG = "~/.svn2git/authors-prog"
 
   class Migration
 
@@ -54,6 +55,10 @@ module Svn2Git
 
       if File.exists?(File.expand_path(DEFAULT_AUTHORS_FILE))
         options[:authors] = DEFAULT_AUTHORS_FILE
+      end
+
+      if File.exists?(File.expand_path(DEFAULT_AUTHORS_PROG))
+        options[:authorsprog] = DEFAULT_AUTHORS_PROG
       end
 
 
@@ -119,6 +124,10 @@ module Svn2Git
           options[:authors] = authors
         end
 
+        opts.on('--authors-prog AUTHORS_PROG', "Path to script containing svn-to-git authors mapping (default: #{DEFAULT_AUTHORS_PROG})") do |authorsprog|
+          options[:authorsprog] = authorsprog
+        end
+
         opts.on('--exclude REGEX', 'Specify a Perl regular expression to filter paths when fetching; can be used multiple times') do |regex|
           options[:exclude] << regex
         end
@@ -163,6 +172,7 @@ module Svn2Git
       nominimizeurl = @options[:nominimizeurl]
       rootistrunk = @options[:rootistrunk]
       authors = @options[:authors]
+      authorsprog = @options[:authorsprog]
       exclude = @options[:exclude]
       revision = @options[:revision]
       username = @options[:username]
@@ -199,6 +209,7 @@ module Svn2Git
       run_command("#{git_config_command} svn.authorsfile #{authors}") unless authors.nil?
 
       cmd = "git svn fetch "
+      cmd += "--authors-prog=#{authorsprog} " unless authorsprog.nil?
       unless revision.nil?
         range = revision.split(":")
         range[1] = "HEAD" unless range[1]
@@ -233,11 +244,11 @@ module Svn2Git
     end
 
     def get_rebasebranch
-	  get_branches 
+	  get_branches
 	  @local = @local.find_all{|l| l == @options[:rebasebranch]}
 	  @remote = @remote.find_all{|r| r.include? @options[:rebasebranch]}
 
-      if @local.count > 1 
+      if @local.count > 1
         pp "To many matching branches found (#{@local})."
         exit 1
       elsif @local.count == 0
@@ -298,11 +309,14 @@ module Svn2Git
     end
 
     def fix_branches
+      authorsprog = @options[:authorsprog]
       svn_branches = @remote - @tags
       svn_branches.delete_if { |b| b.strip !~ %r{^svn\/} }
 
       if @options[:rebase]
-         run_command("git svn fetch", true, true)
+         cmd = "git svn fetch"
+         cmd += " --authors-prog=#{authorsprog}" unless authorsprog.nil?
+         run_command(cmd, true, true)
       end
 
       svn_branches.each do |branch|


### PR DESCRIPTION
Thanks for the great utility. I needed the ability to pass the --authors-prog flag to handle SVN usernames that were not found in the authors file. Sadly, this flag doesn't have a git config key like svn.authorsfile, so you have to pass the flag again if you want to use it with the --rebase. Otherwise, it works great for me (tm). Thought I would contribute my changes back. Hope this helps.
