### PR TITLE
add MIT license metadata to gemspec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,7 @@ begin
     spec.homepage = "https://github.com/nirvdrum/svn2git"
     spec.email = "nirvdrum@gmail.com"
     spec.add_development_dependency 'test-unit'
+    spec.license 'MIT'
   end
   Jeweler::GemcutterTasks.new
   

--- a/svn2git.gemspec
+++ b/svn2git.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/nirvdrum/svn2git"
   s.rubygems_version = "2.2.2"
   s.summary = "A tool for migrating svn projects to git"
+  s.license = "MIT"
 
   if s.respond_to? :specification_version then
     s.specification_version = 4


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
