### PR TITLE
tests: switch to minitest

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ begin
     spec.homepage = "https://github.com/nirvdrum/svn2git"
     spec.email = "nirvdrum@gmail.com"
     spec.license = 'MIT'
-    spec.add_development_dependency 'test-unit'
+    spec.add_development_dependency 'minitest'
     spec.add_dependency 'open4'
   end
   Jeweler::GemcutterTasks.new

--- a/svn2git.gemspec
+++ b/svn2git.gemspec
@@ -40,14 +40,14 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_development_dependency(%q<test-unit>, [">= 0"])
+      s.add_development_dependency(%q<minitest>, [">= 0"])
       s.add_runtime_dependency(%q<open4>, [">= 0"])
     else
-      s.add_dependency(%q<test-unit>, [">= 0"])
+      s.add_dependency(%q<minitest>, [">= 0"])
       s.add_dependency(%q<open4>, [">= 0"])
     end
   else
-    s.add_dependency(%q<test-unit>, [">= 0"])
+    s.add_dependency(%q<minitest>, [">= 0"])
     s.add_dependency(%q<open4>, [">= 0"])
   end
 end

--- a/test/escape_quotes_test.rb
+++ b/test/escape_quotes_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.join(__FILE__, '..', 'test_helper'))
 
-class EscapeQuotesTest < Test::Unit::TestCase
+class EscapeQuotesTest < Minitest::Test
   def test_identity
     expected = 'A string without any need to escape.'
     actual = Svn2Git::Migration.escape_quotes(expected)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,12 @@
 $:.unshift "#{File.dirname(__FILE__)}/../lib"
 
+require 'rubygems'
 require 'svn2git'
-require 'test/unit'
+require 'minitest/autorun'
+
+if Minitest.const_defined?('Test')
+  # We're on Minitest 5+. Nothing to do here.
+else
+  # Minitest 4 doesn't have Minitest::Test yet.
+  Minitest::Test = MiniTest::Unit::TestCase
+end


### PR DESCRIPTION
Ruby 1.9+ uses Minitest as the backend for Test::Unit. As of Minitest 5, the shim no longer supports Test::Unit::TestCase.

Adjust the svn2git test suite to support Minitest 5's syntax.

Minitest versions 4 and below do not support the newer Minitest::Test class that arrived in version 5. For that case, use the MiniTest::Unit::TestCase class as a fallback.
