### PR TITLE
Remove unnecessary package install in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -66,7 +66,7 @@ Installation
 
 Make sure you have git, git-svn, and ruby installed.  svn2git is a ruby wrapper around git's native SVN support through git-svn.  It is possible to have git installed without git-svn installed, so please do verify that you can run `$ git svn` successfully.  For a Debian-based system, the installation of the prerequisites would look like:
 
-    $ sudo apt-get install git-core git-svn ruby rubygems
+    $ sudo apt-get install git-core git-svn ruby
 
 Once you have the necessary software on your system, you can install svn2git through rubygems, which will add the `svn2git` command to your PATH.    
 


### PR DESCRIPTION
On Debian systems, the `rubygems` package has been rolled into the `ruby` package.