### PR TITLE
use fatal to detect branch tracking failure, for other languages to work

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -335,7 +335,7 @@ module Svn2Git
           # Our --rebase option obviates the need for read-only tracked remotes, however.  So, we'll
           # deprecate the old option, informing those relying on the old behavior that they should
           # use the newer --rebase otion.
-          if status =~ /Cannot setup tracking information/m
+          if status =~ /fatal/m
             @cannot_setup_tracking_information = true
             run_command(Svn2Git::Migration.checkout_svn_branch(branch))
           else


### PR DESCRIPTION
Using "Cannot setup tracking information" make the logic fails if another language than english is used.
Although "fatal" may indicate another error, it should work with all languages.
Another option could be to force "LANG=C" before calling any git commands.
