### PR TITLE
allows multiple tags and branches options

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -47,8 +47,8 @@ module Svn2Git
       options[:nominimizeurl] = false
       options[:rootistrunk] = false
       options[:trunk] = 'trunk'
-      options[:branches] = 'branches'
-      options[:tags] = 'tags'
+      options[:branches] = []
+      options[:tags] = []
       options[:exclude] = []
       options[:revision] = nil
       options[:username] = nil
@@ -79,11 +79,11 @@ module Svn2Git
         end
 
         opts.on('--branches BRANCHES_PATH', 'Subpath to branches from repository URL (default: branches)') do |branches|
-          options[:branches] = branches
+          options[:branches] << branches
         end
 
         opts.on('--tags TAGS_PATH', 'Subpath to tags from repository URL (default: tags)') do |tags|
-          options[:tags] = tags
+          options[:tags] << tags
         end
 
         opts.on('--rootistrunk', 'Use this if the root level of the repo is equivalent to the trunk and there are no tags or branches') do
@@ -145,6 +145,14 @@ module Svn2Git
 
       @opts.parse! args
       options
+
+      # Set default branches and tags if not explicitely configured
+     if ! options[:branches].nil? && options[:branches].length == 0 
+         options[:branches] << 'branches'
+       end
+       if ! options[:tags].nil? && options[:tags].length == 0 
+         options[:tags] << 'tags'
+       end
     end
 
     def self.escape_quotes(str)
@@ -194,8 +202,12 @@ module Svn2Git
           cmd += "--no-minimize-url "
         end
         cmd += "--trunk=#{trunk} " unless trunk.nil?
-        cmd += "--tags=#{tags} " unless tags.nil?
-        cmd += "--branches=#{branches} " unless branches.nil?
+        tags.each do |tags|
+          cmd += "--tags=#{tags} "
+        end unless tags.nil?
+        branches.each do |branches|
+          cmd += "--branches=#{branches} "
+        end unless branches.nil?
 
         cmd += @url
 


### PR DESCRIPTION
svn2git doesn't natively allow multiple --tags= or --branches= options. This corrects this. 
