### PR TITLE
Fixed creation of the local branches with Git >= 2

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -349,7 +349,7 @@ module Svn2Git
 
             @legacy_svn_branch_tracking_message_displayed = true
 
-            run_command("git checkout \"#{branch}\"")
+            run_command("git checkout -b \"#{branch}\" \"remotes/svn/#{branch}\"")
           end
         end
       end


### PR DESCRIPTION
With an up-to-date Git (tested with 2.1.3), the shorthand `git checkout "branchname"`, to create a local "non-tracking" branch from the remote svn branch, does not work any more.
This replaces the shorthand with an explicit command.
