### PR TITLE
Stop README ID-extract snippet leaving spaces end of line

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -176,11 +176,11 @@ repository which name on its own line. This would allow you to easily
 redirect the output of this command sequence to `~/.svn2git/authors` and have
 a very good starting point for your mapping.
 
-    $ svn log --quiet | grep -E "r[0-9]+ \| .+ \|" | cut -d'|' -f2 | sed 's/^ //' | sort | uniq
+    $ svn log --quiet | grep -E "r[0-9]+ \| .+ \|" | cut -d'|' -f2 | sed 's/ //g' | sort | uniq
 
 Or, for a remote URL:
 
-    $ svn log --quiet http://path/to/root/of/project | grep -E "r[0-9]+ \| .+ \|" | cut -d'|' -f2 | sed 's/^ //' | sort | uniq
+    $ svn log --quiet http://path/to/root/of/project | grep -E "r[0-9]+ \| .+ \|" | cut -d'|' -f2 | sed 's/ //g' | sort | uniq
 
 Debugging
 ---------


### PR DESCRIPTION
@nirvdrum Hopefully not controversial - currently the snippet leaves spaces on the ends of lines.