### PR TITLE
Fix for --rebase failing on repositories with a lot of branches

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -238,8 +238,8 @@ module Svn2Git
     def get_branches
       # Get the list of local and remote branches, taking care to ignore console color codes and ignoring the
       # '*' character used to indicate the currently selected branch.
-      @local = run_command("git branch -l --no-color").split(/\n/).collect{ |b| b.gsub(/\*/,'').strip }
-      @remote = run_command("git branch -r --no-color").split(/\n/).collect{ |b| b.gsub(/\*/,'').strip }
+      @local = run_command("git branch --no-column -l --no-color").split(/\n/).collect{ |b| b.gsub(/\*/,'').strip }
+      @remote = run_command("git branch --no-column -r --no-color").split(/\n/).collect{ |b| b.gsub(/\*/,'').strip }
 
       # Tags are remote branches that start with "tags/".
       @tags = @remote.find_all { |b| b.strip =~ %r{^svn\/tags\/} }


### PR DESCRIPTION
A repository I'm migrating has enough branches where `git branch` displays them in multiple columns, which seems to break `svn2git --rebase`. Adding the `--no-column` flag ensures there will be just one branch listed per line, which fixed the issue for me locally.