### PR TITLE
escape dollar signs along with our quotes

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -154,6 +154,7 @@ module Svn2Git
 
     def self.escape_quotes(str)
       str.gsub(/'|"/) { |c| "\\#{c}" }
+         .gsub(/\$/)  { |c| '\\$' }
     end
 
     def escape_quotes(str)


### PR DESCRIPTION
self.escape_quotes is used for putting everything in double quotes, but a $ in double quotes isn't happy, for example:

```
Running command: git tag -a -m "fix ${ => #{ typo" "FOO@7974" "svn/tags/FOO@7974"
sh: 1: Syntax error: Unterminated quoted string
command failed:
git tag -a -m "fix ${ => #{ typo" "FOO@7974" "svn/tags/FOO@7974"
```

With this patch:

```
Running command: git tag -a -m "fix \${ => #{ typo" "FOO@7974" "svn/tags/FOO@7974"
```
