### PR TITLE
Fix exclude arg (incorrectly quoted string)

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -228,7 +228,7 @@ module Svn2Git
           regex << "#{branches}[/][^/]+[/]" unless branches.nil?
         end
         regex = '^(?:' + regex.join('|') + ')(?:' + exclude.join('|') + ')'
-        cmd += "'--ignore-paths=#{regex}'"
+        cmd += "--ignore-paths='#{regex}' "
       end
       run_command(cmd, true, true)
 


### PR DESCRIPTION
The quote in the appended `--ignore-paths` cmd argument is in the wrong
place.  Also add the conventional space in case of additional future
args.