### PR TITLE
Prevent errors from "&" in svn URI.

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -219,7 +219,7 @@ module Svn2Git
           end
         end
 
-        cmd += @url
+        cmd += '"' + @url + '"'
 
         run_command(cmd, true, true)
       end


### PR DESCRIPTION
Added " around the url in the fetch so it works with special charactors in the svn url. (Tested to work with an & in the URL).