### PR TITLE
Docker: add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:16.04
+RUN apt-get -qq update
+RUN apt-get -q -y install git-core git-svn ruby
+RUN gem install svn2git
+CMD ["svn2git"]


### PR DESCRIPTION
Since svn2git is often used for one-shot conversion, it makes sense to dockerize it instead of installing its dependencies.