### PR TITLE
Add ability to specify primary Git branches other than 'master'

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -1,3 +1,8 @@
+# 2.5.0 - 2021-02-27
+
+	This release introduces the ability to specify primary Git branches other than 'master'.
+	'master' remains the default primary branch name for backwards compatibility.
+
 # 2.4.0 - 2016-10-30
 
   This release introduces the ability to supply a password for SVN repositories that can't authenticate by other means.

--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -1,7 +1,7 @@
 # 2.5.0 - 2021-02-27
 
-	This release introduces the ability to specify primary Git branches other than 'master'.
-	'master' remains the default primary branch name for backwards compatibility.
+  This release introduces the ability to specify primary Git branches other than 'master'.
+  'master' remains the default primary branch name for backwards compatibility.
 
 # 2.4.0 - 2016-10-30
 

--- a/README.markdown
+++ b/README.markdown
@@ -205,6 +205,7 @@ Options Reference
     
     Specific options:
             --rebase                     Instead of cloning a new project, rebase an existing one against SVN
+            --primarybranch              Use with --rebase if your primary branch has a name other than 'master'
             --username NAME              Username for transports that needs it (http(s), svn)
             --password PASS              Password for transports that needs it (http(s), svn)
             --trunk TRUNK_PATH           Subpath to trunk from repository URL (default: trunk)
@@ -227,13 +228,13 @@ Options Reference
 FAQ
 ---
 
-1. Why don't the tags show up in the master branch?
+1. Why don't the tags show up in the primary branch?
 
-    The tags won't show up in the master branch because the tags are actually
+    The tags won't show up in the primary branch because the tags are actually
     tied to the commits that were created in svn when the user made the tag.
     Those commits are the first (head) commit of branch in svn that is
     associated with that tag. If you want to see all the branches and tags
-    and their relationships in gitk you can run the following: gitk --all
+    and their relationships in gitk you can run the following: `gitk --all`
     
     For further details please refer to FAQ #2.
     
@@ -253,4 +254,8 @@ FAQ
     that very same tag in the original svn repo. This is only due to the fact
     that the svn tags allow changesets in them, making them not just annotated
     tags.
+    
+3. Why does the primary branch default to 'master'?
+
+		This has been left in for backwards compatability purposes.
 

--- a/README.markdown
+++ b/README.markdown
@@ -257,5 +257,5 @@ FAQ
     
 3. Why does the primary branch default to 'master'?
 
-		This has been left in for backwards compatability purposes.
+    This has been left in for backwards compatability purposes.
 

--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -72,7 +72,7 @@ module Svn2Git
           options[:rebase] = true
         end
         
- 				opts.on('--primarybranch BRANCH_NAME', 'Name of Git repo primary branch') do |primarybranch|
+ 	opts.on('--primarybranch BRANCH_NAME', 'Name of Git repo primary branch') do |primarybranch|
           options[:primarybranch] = primarybranch
         end
         


### PR DESCRIPTION
This PR adds an additional option (`--primarybranch`) to allow users to specify a primary branch for their Git repo. other than `master` (e.g., `main`).