### PR TITLE
Replace support for --password

### DIFF
--- a/ChangeLog.markdown
+++ b/ChangeLog.markdown
@@ -1,3 +1,9 @@
+# 2.4.1 - 2021-12-17
+
+  Since 'git-svn' does not support '--password' anymore, this release modifies the mechanism to supply a password when needed.
+
+  * Removed support for '--password' option (jesteves; PR merge pending).
+  * Added support for detecting and using the value of the environment variable 'SVN2GIT_PASSWORD' when `svn git` is invoked (jesteves; PR merge pending).
 # 2.4.0 - 2016-10-30
 
   This release introduces the ability to supply a password for SVN repositories that can't authenticate by other means.

--- a/README.markdown
+++ b/README.markdown
@@ -120,7 +120,8 @@ one of them.
 
 If this doesn't cooperate and you need to specify a password on the command-line:
 
-        $ svn2git http://svn.example.com/path/to/repo --username <<user_with_perms>> --password <<password>>
+        $ # define environment variable SVN2GIT_PASSWORD=<<password>> according to shell syntax
+        $ svn2git http://svn.example.com/path/to/repo --username <<user_with_perms>>
 
 8. You need to migrate starting at a specific svn revision number.
 
@@ -206,7 +207,6 @@ Options Reference
     Specific options:
             --rebase                     Instead of cloning a new project, rebase an existing one against SVN
             --username NAME              Username for transports that needs it (http(s), svn)
-            --password PASS              Password for transports that needs it (http(s), svn)
             --trunk TRUNK_PATH           Subpath to trunk from repository URL (default: trunk)
             --branches BRANCHES_PATH     Subpath to branches from repository URL (default: branches); can be used multiple times
             --tags TAGS_PATH             Subpath to tags from repository URL (default: tags); can be used multiple times

--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
 :major: 2
 :minor: 4
-:patch: 0
+:patch: 1
 :build: 


### PR DESCRIPTION
[git-svn](https://git-scm.com/docs/git-svn) does not support `--password` anymore.

This commit removes the command line option for svn2git since it ultimately passed its value to `svn-git.

If the SVN transport requires a password, svn-git will always prompt the user for it, so now svn2git will detect the presence of the SVN2GIT_PASSWORD environment variable and pass its value in reply to the prompt.