### PR TITLE
Fix crash with Ruby-3.2

### DIFF
--- a/lib/svn2git/migration.rb
+++ b/lib/svn2git/migration.rb
@@ -55,7 +55,7 @@ module Svn2Git
       options[:password] = nil
       options[:rebasebranch] = false
 
-      if File.exists?(File.expand_path(DEFAULT_AUTHORS_FILE))
+      if File.exist?(File.expand_path(DEFAULT_AUTHORS_FILE))
         options[:authors] = DEFAULT_AUTHORS_FILE
       end
 


### PR DESCRIPTION
svn2git fails to work with Ruby-3.2 and gives the following error:
```
/usr/lib/ruby/vendor_ruby/svn2git/migration.rb:58:in `parse': undefined method `exists?' for File:Class (NoMethodError)

      if File.exists?(File.expand_path(DEFAULT_AUTHORS_FILE))
             ^^^^^^^^
Did you mean?  exist?
	from /usr/lib/ruby/vendor_ruby/svn2git/migration.rb:14:in `initialize'
	from /usr/bin/svn2git:26:in `new'
	from /usr/bin/svn2git:26:in `<main>'
```